### PR TITLE
Fix FilterExpression to retain value passed in.

### DIFF
--- a/Source/QueryAPI/Models/FilterExpression.cs
+++ b/Source/QueryAPI/Models/FilterExpression.cs
@@ -52,6 +52,7 @@ namespace BingMapsSDSToolkit.QueryAPI
         {
             PropertyName = propertyName;
             Operator = logicalOperator;
+            Value = value;
         }
 
         #endregion


### PR DESCRIPTION
- FilterExpression is not storing the passed in value, which prevents filters from actually filtering.
- This can be worked around by double setting filter:

		var expression = new FilterExpression("EntityTypeID", LogicalOperator.IsIn, new List<string>() { "5800" });
		expression.Value = new List<string>() { "5800" };

but this is obviously not expected behavior.